### PR TITLE
kingbank kp260 compatibility

### DIFF
--- a/docs/data/hardwares/SSD_NVME/kingbank/kp260.yml
+++ b/docs/data/hardwares/SSD_NVME/kingbank/kp260.yml
@@ -1,0 +1,9 @@
+model: KP260
+arch: KingBank KP260
+brand: KingBank
+type: SSD_NVMe 
+status: 1 
+notes: 
+notes_en: 
+link: 
+link_en: 


### PR DESCRIPTION
3A6000 EVB (XA612A0 v1.1) plays well with KingBank KP260. 